### PR TITLE
Add Color conversion

### DIFF
--- a/sgr.go
+++ b/sgr.go
@@ -3,9 +3,18 @@ package sgr
 
 import (
 	"fmt"
+	"math"
 )
 
 type SGR string
+
+var Config struct {
+	Depth int
+}
+
+func init() {
+	Config.Depth = 24
+}
 
 const (
 	csi             = string(rune(27)) + string('[')
@@ -66,27 +75,6 @@ const (
 	NoOverline  SGR = "55"
 )
 
-// ForeRGB is not supported by all terms. I know it works with Xterm
-func ForeRGB(r, g, b byte) SGR {
-	return SGR(fmt.Sprintf("%d;2;%d;%d;%d", ForeExtd, r, g, b))
-}
-
-// TODO: write a version that can snap to 255 color and 16 color, 8 color based
-// on color depth variable
-
-// BackRGB is not supported by all terms. I know it works with Xterm
-func BackRGB(r, g, b byte) SGR {
-	return SGR(fmt.Sprintf("%d;2;%d;%d;%d", BackExtd, r, g, b))
-}
-
-func ForeCode(code byte) SGR {
-	return SGR(fmt.Sprintf("%d;5;%d", ForeExtd, code))
-}
-
-func BackCode(code byte) SGR {
-	return SGR(fmt.Sprintf("%d;5;%d", BackExtd, code))
-}
-
 type Style []SGR
 
 func (s Style) String() string {
@@ -128,4 +116,165 @@ func (t Text) Format(f fmt.State, c rune) {
 	format += string(newRune)
 
 	f.Write([]byte(fmt.Sprintf(format, pre+t.Value+post)))
+}
+
+// representation of a 24 bit color
+type Color24 struct {
+	R byte
+	G byte
+	B byte
+}
+
+// reduce nearest color in new color depth
+func (c Color24) To256SGR(background bool) SGR {
+	rgd := math.Abs(float64(c.R - c.G))
+	rbd := math.Abs(float64(c.R - c.B))
+	gbd := math.Abs(float64(c.G - c.B))
+
+	var fgbg SGR
+	if background {
+		fgbg = "48;5;"
+	} else {
+		fgbg = "38;5;"
+	}
+
+	// Use the sum of the differences to decide whether C is a color or a grey
+	if rgd+rbd+gbd > 8 {
+		r := int((float32(c.R)/255*5)+0.5) * 36
+		g := int((float32(c.G)/255*5)+0.5) * 6
+		b := int((float32(c.B) / 255 * 5) + 0.5)
+		return SGR(fmt.Sprintf("%s%d", fgbg, 16+r+g+b))
+	} else {
+		// process as a grey.
+		// average the rgb values and match nearest:
+		result := greyOrder256[int((float32(c.R)+float32(c.G)+float32(c.B))/3/255*30+0.5)]
+		return SGR(fmt.Sprintf("%s%d", fgbg, result))
+	}
+}
+
+// reduce nearest color in new color depth
+func (c Color24) To16SGR(background bool) SGR {
+	var fgbg int
+	if background {
+		fgbg = 40
+	} else {
+		fgbg = 30
+	}
+
+	rgd := math.Abs(float64(c.R - c.G))
+	rbd := math.Abs(float64(c.R - c.B))
+	gbd := math.Abs(float64(c.G - c.B))
+
+	r := int((float32(c.R) / 255 * 3) + 0.5)
+	g := int((float32(c.G) / 255 * 3) + 0.5)
+	b := int((float32(c.B) / 255 * 3) + 0.5)
+
+	var result int
+
+	// Use the sum of the differences to decide whether C is a color or a grey
+	if rgd+rbd+gbd > 8 {
+
+		switch {
+		case r == 0 && g == 0 && b == 0:
+			result = 0
+		case r == 1 && g == 0 && b == 0:
+			result = 1
+		case r == 0 && g == 1 && b == 0:
+			result = 2
+		case r == 1 && g == 1 && b == 0:
+			result = 3
+		case r == 0 && g == 0 && b == 1:
+			result = 4
+		case r == 1 && g == 0 && b == 1:
+			result = 5
+		case r == 0 && g == 1 && b == 1:
+			result = 6
+		case r == 1 && g == 1 && b == 1:
+			result = 8
+		case r == 2 && g == 0 && b == 0:
+			result = 9
+		case r == 0 && g == 2 && b == 0:
+			result = 10
+		case r == 2 && g == 2 && b == 0:
+			result = 11
+		case r == 0 && g == 0 && b == 2:
+			result = 12
+		case r == 2 && g == 0 && b == 2:
+			result = 13
+		case r == 0 && g == 2 && b == 2:
+			result = 14
+		case r == 2 && g == 2 && b == 2:
+			result = 15
+		}
+	} else {
+		// process as a grey.
+		// average the rgb values and match nearest:
+		switch a := float64(r+g+b) / 3; {
+		case a < 1.0:
+			result = 0
+		case a >= 1 && a < 2.0:
+			result = 8
+		case a >= 2.0 && a < 3.0:
+			result = 7
+		default:
+			result = 15
+		}
+	}
+	var s SGR
+	if result > 7 {
+		s = Bold + ";"
+		result -= 7
+	}
+	s += SGR(fmt.Sprintf("%d", result+fgbg))
+	return s
+}
+
+func (c Color24) ToRealSGR(background bool) SGR {
+	var result SGR
+	var fgbg SGR
+	if background {
+		fgbg = "48"
+	} else {
+		fgbg = "38"
+	}
+	result = SGR(fmt.Sprintf("%s;2;%d;%d;%d", fgbg, c.R, c.G, c.B))
+	return result
+}
+
+var greyOrder256 = [...]int{
+	16,
+	232,
+	233,
+	234,
+	235,
+	236,
+	237,
+	238,
+	239,
+	240,
+	59,
+	241,
+	242,
+	243,
+	244,
+	102,
+	245,
+	246,
+	247,
+	248,
+	139,
+	145,
+	249,
+	250,
+	251,
+	252,
+	188,
+	253,
+	254,
+	255,
+	231,
+}
+
+func (c Color24) String() string {
+	return fmt.Sprintf("#%0.2x%0.2x%0.2x", c.R, c.G, c.B)
 }


### PR DESCRIPTION
Color conversions map the RGB Color object into codes suitable for 16, 218, and true color-enabled terms
